### PR TITLE
teminate pgsql_socket on terminate pgsql_proto correctly

### DIFF
--- a/src/pgsql_proto.erl
+++ b/src/pgsql_proto.erl
@@ -65,7 +65,7 @@
 -import(pgsql_util, [to_integer/1, to_atom/1]).
 
 -record(state, {options, ssl_options, transport,
-		driver, params, socket, oidmap, as_binary}).
+		driver, params, socket, oidmap, as_binary, ctl_socket}).
 
 start(Options) ->
     gen_server:start(?MODULE, [self(), Options], []).
@@ -252,7 +252,7 @@ connected(StateData, Sock) ->
 		      Rows),
     OidMap = dict:from_list(Rows1),
 
-    {ok, StateData#state{oidmap = OidMap}}.
+    {ok, StateData#state{oidmap = OidMap, ctl_socket = Unwrapper}}.
 
 
 handle_call(terminate, _From, State) ->
@@ -428,7 +428,8 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 
-terminate(_Reason, _State) ->
+terminate(_Reason, State) ->
+	ok = gen_server:call(State#state.ctl_socket, terminate),
     ok.
 
 

--- a/src/pgsql_socket.erl
+++ b/src/pgsql_socket.erl
@@ -30,6 +30,8 @@ init([{Mod, Sock}, ProtoPid, AsBin]) ->
     {ok, #state{socket = Sock, sockmod = Mod, protopid = ProtoPid,
                 buffer = <<>>, as_binary = AsBin}}.
 
+handle_call(terminate, _From, State) ->
+    {stop, normal, ok, State};
 handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
@@ -64,7 +66,8 @@ handle_info({Tag, Sock, Reason},
     io:format("Sock error~n", []),
     ProtoPid ! {socket, {Mod, Sock}, {error, Reason}},
     {stop, tcp_error, State};
-handle_info(_Info, State) ->
+handle_info(Info, State) ->
+    io:format("Unhandled pgsql_socket message: ~p~n", [Info]),
     {noreply, State}.
 
 


### PR DESCRIPTION
Process pgsql_socket does not terminate correctly on closing connection by pgsql:terminate/1.

pgsql_socket linked with pgsql_proto which terminates on pgsql:terminate/1, but pgsql_socket stay running anyway. I don`t now why it happends. I just create terminate method for pgsql_socket and call in on terminate pgsql_proto