### PR TITLE
let extended queries handle empty responses

### DIFF
--- a/src/pgsql_proto.erl
+++ b/src/pgsql_proto.erl
@@ -504,7 +504,7 @@ process_equery_nodata(Log, Command) ->
     {pgsql, {ready_for_query, Status1}} ->
         {ok, Command, [], Status1, lists:reverse(Log)};
     {pgsql, Any} ->
-        process_equery_nodata([Any|Log], Command);
+        process_equery_nodata([Any|Log], Command)
     end.
 
 process_equery_datarow(Types, Log, Info={Command, Desc, Status}, AsBin) ->


### PR DESCRIPTION
Some queries return empty data sets. In case extended query mechanism was used - whole process would be hung in a 'receive' with no results.
This patch lets p1_pgsql handle such queries and return back to 'ready for query' state.